### PR TITLE
Fix font at icon

### DIFF
--- a/srtdash/assets/css/styles.css
+++ b/srtdash/assets/css/styles.css
@@ -512,6 +512,7 @@
     position: absolute;
     right: -5px;
     top: -7px;
+    font-family: 'Poppins', sans-serif;
     font-size: 10px;
     font-weight: 600;
     color: #fff;


### PR DESCRIPTION
The font in the top-right menubar is not the same as everywhere else in the dashboard
![Serif font](https://user-images.githubusercontent.com/23698324/50209377-dddecf80-0373-11e9-83a5-2e70dd89ceb2.PNG)

This pull changes the font to Poppins
![Poppins font](https://user-images.githubusercontent.com/23698324/50209378-dddecf80-0373-11e9-99ea-6bf290ce8be6.PNG)
